### PR TITLE
Simplify sidebar partial template

### DIFF
--- a/themes/barricade/layouts/partials/sidebar.html
+++ b/themes/barricade/layouts/partials/sidebar.html
@@ -7,15 +7,14 @@
 
   <nav class="sidebar-nav">
     <ul>
-      {{ $currentNode := . }}
       {{ range .Site.Menus.main }}
-      <li><a class="sidebar-nav-item{{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} active{{end}}" href="{{.URL}}">
+      <li><a class="sidebar-nav-item{{if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }} active{{end}}" href="{{.URL}}">
           <span class="ripple">{{ .Name }} <span></span></span>
         </a>
         {{ if .HasChildren }}
         <ul>
           {{ range .Children.ByWeight }}
-            <li{{if $currentNode.IsMenuCurrent "main" . }} class="active"{{end}}><a href="#{{.URL}}">{{ .Name }}</a></li>
+            <li{{if $.IsMenuCurrent "main" . }} class="active"{{end}}><a href="#{{.URL}}">{{ .Name }}</a></li>
           {{ end }}
         </ul>
         {{end}}


### PR DESCRIPTION
In Go templates, the initial template context is always available as `$`.
